### PR TITLE
Update C00.csv to correct XML tags in C00.xml

### DIFF
--- a/C00.csv
+++ b/C00.csv
@@ -1,4 +1,4 @@
-GRIB version number,BUFR version number,CREX version number,Effective date,Status 
+GRIB version number,BUFR version number,CREX version number,Effective date,Status
 0,0,0,Experimental,Operational
 ,1,,1 November 1988,Operational
 ,2,,1 November 1993,Operational


### PR DESCRIPTION
Due to the last change to C00.csv to kick off XML generation, C00.xml currently has `<Status->` tags instead of `<Status>` tags.

This commit will trigger again the script, which will fix that issue.